### PR TITLE
Claude/analyze us exchange g6 b kg

### DIFF
--- a/bex/entrys.go
+++ b/bex/entrys.go
@@ -8,6 +8,7 @@ import (
 	"github.com/banbox/banexg/errs"
 	"github.com/banbox/banexg/okx"
 	"github.com/banbox/banexg/utils"
+	"github.com/banbox/banexg/yahoo"
 )
 
 func init() {
@@ -16,6 +17,7 @@ func init() {
 		"bybit":   WrapNew(bybit.New),
 		"china":   china.NewExchange,
 		"okx":     okx.NewExchange,
+		"yahoo":   yahoo.NewExchange,
 	}
 }
 

--- a/yahoo/biz.go
+++ b/yahoo/biz.go
@@ -26,12 +26,19 @@ func (e *Yahoo) Init() *errs.Error {
 		"30m": "30m",
 		"60m": "60m",
 		"1h":  "60m",
+		"1H":  "60m",
 		"90m": "90m",
+		// 4h has no native Yahoo interval; FetchOHLCV aggregates from 1h.
+		"4h":  "4h",
+		"4H":  "4h",
 		"1d":  "1d",
+		"1D":  "1d",
 		"5d":  "5d",
 		"1w":  "1wk",
+		"1W":  "1wk",
 		"1wk": "1wk",
 		"1mo": "1mo",
+		"1M":  "1mo",
 		"3mo": "3mo",
 	}
 	e.ExgInfo.Min1mHole = 1
@@ -99,6 +106,22 @@ func (e *Yahoo) FetchOHLCV(symbol, timeframe string, since int64, limit int, par
 	interval := e.GetTimeFrame(timeframe)
 	if interval == "" {
 		return nil, errs.NewMsg(errs.CodeInvalidTimeFrame, "unsupported timeframe: %s", timeframe)
+	}
+	// 4h has no native Yahoo interval; fetch 1h and aggregate.
+	if interval == "4h" {
+		baseLimit := 0
+		if limit > 0 {
+			baseLimit = limit * 4
+		}
+		base, err := e.FetchOHLCV(symbol, "1h", since, baseLimit, params)
+		if err != nil {
+			return nil, err
+		}
+		out := aggregate(base, 4*60*60*1000)
+		if limit > 0 && len(out) > limit {
+			out = out[len(out)-limit:]
+		}
+		return out, nil
 	}
 	args := utils.SafeParams(params)
 	args["symbol"] = symbol

--- a/yahoo/biz.go
+++ b/yahoo/biz.go
@@ -1,0 +1,187 @@
+package yahoo
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/banbox/banexg"
+	"github.com/banbox/banexg/errs"
+	"github.com/banbox/banexg/utils"
+)
+
+func (e *Yahoo) Init() *errs.Error {
+	if err := e.Exchange.Init(); err != nil {
+		return err
+	}
+	if e.UserAgent == "" {
+		e.UserAgent = defaultUserAgent
+	}
+	e.TimeFrames = map[string]string{
+		"1m":  "1m",
+		"2m":  "2m",
+		"5m":  "5m",
+		"15m": "15m",
+		"30m": "30m",
+		"60m": "60m",
+		"1h":  "60m",
+		"90m": "90m",
+		"1d":  "1d",
+		"5d":  "5d",
+		"1w":  "1wk",
+		"1wk": "1wk",
+		"1mo": "1mo",
+		"3mo": "3mo",
+	}
+	e.ExgInfo.Min1mHole = 1
+	e.MarketsLock.Lock()
+	if e.Markets == nil {
+		e.Markets = banexg.MarketMap{}
+	}
+	e.MarketsLock.Unlock()
+	e.MarketsByIdLock.Lock()
+	if e.MarketsById == nil {
+		e.MarketsById = banexg.MarketArrMap{}
+	}
+	e.MarketsByIdLock.Unlock()
+	return nil
+}
+
+// LoadMarkets is lazy: Yahoo has no "list all instruments" endpoint.
+// If params[ParamSymbols] is provided, build Market entries for those tickers;
+// otherwise return whatever has accumulated via earlier MapMarket calls.
+func (e *Yahoo) LoadMarkets(reload bool, params map[string]interface{}) (banexg.MarketMap, *errs.Error) {
+	var symbols []string
+	if params != nil {
+		if v, ok := params[banexg.ParamSymbols]; ok && v != nil {
+			symbols, _ = v.([]string)
+		}
+	}
+	for _, s := range symbols {
+		if s == "" {
+			continue
+		}
+		e.registerMarket(buildMarket(s))
+	}
+	e.MarketsLock.Lock()
+	out := e.Markets
+	e.MarketsLock.Unlock()
+	return out, nil
+}
+
+// MapMarket builds a Market on demand for a Yahoo ticker.
+func (e *Yahoo) MapMarket(rawID string, year int) (*banexg.Market, *errs.Error) {
+	if rawID == "" {
+		return nil, errs.NewMsg(errs.CodeParamRequired, "symbol required")
+	}
+	if mar := e.GetMarketById(rawID, ""); mar != nil {
+		return mar, nil
+	}
+	m := buildMarket(rawID)
+	e.registerMarket(m)
+	return m, nil
+}
+
+func (e *Yahoo) registerMarket(m *banexg.Market) {
+	e.MarketsLock.Lock()
+	e.Markets[m.Symbol] = m
+	e.MarketsLock.Unlock()
+	e.MarketsByIdLock.Lock()
+	e.MarketsById[m.ID] = []*banexg.Market{m}
+	e.MarketsByIdLock.Unlock()
+}
+
+func (e *Yahoo) FetchOHLCV(symbol, timeframe string, since int64, limit int, params map[string]interface{}) ([]*banexg.Kline, *errs.Error) {
+	if symbol == "" {
+		return nil, errs.NewMsg(errs.CodeParamRequired, "symbol required")
+	}
+	interval := e.GetTimeFrame(timeframe)
+	if interval == "" {
+		return nil, errs.NewMsg(errs.CodeInvalidTimeFrame, "unsupported timeframe: %s", timeframe)
+	}
+	args := utils.SafeParams(params)
+	args["symbol"] = symbol
+	args[banexg.ParamInterval] = interval
+	args["events"] = "history"
+
+	until := utils.PopMapVal(args, banexg.ParamUntil, int64(0))
+	if since > 0 {
+		args["period1"] = strconv.FormatInt(since/1000, 10)
+		if until > 0 {
+			args["period2"] = strconv.FormatInt(until/1000, 10)
+		} else {
+			args["period2"] = strconv.FormatInt(time.Now().Unix(), 10)
+		}
+	} else {
+		args["range"] = chooseRange(interval, limit)
+	}
+
+	tryNum := e.GetRetryNum("FetchOHLCV", 1)
+	rsp := e.RequestApiRetry(context.Background(), MidChartGet, args, tryNum)
+	if rsp.Error != nil {
+		return nil, rsp.Error
+	}
+	klines, err := parseChart(rsp.Content)
+	if err != nil {
+		return nil, err
+	}
+	if limit > 0 && len(klines) > limit {
+		// Yahoo doesn't accept a `limit` parameter, so trim from the oldest end.
+		klines = klines[len(klines)-limit:]
+	}
+	return klines, nil
+}
+
+func (e *Yahoo) FetchTickers(symbols []string, params map[string]interface{}) ([]*banexg.Ticker, *errs.Error) {
+	if len(symbols) == 0 {
+		return nil, errs.NewMsg(errs.CodeParamRequired, "symbols required")
+	}
+	args := utils.SafeParams(params)
+	args["symbols"] = strings.Join(symbols, ",")
+
+	tryNum := e.GetRetryNum("FetchTickers", 1)
+	rsp := e.RequestApiRetry(context.Background(), MidQuoteGet, args, tryNum)
+	if rsp.Error != nil {
+		return nil, rsp.Error
+	}
+	return parseQuote(rsp.Content)
+}
+
+func (e *Yahoo) FetchTicker(symbol string, params map[string]interface{}) (*banexg.Ticker, *errs.Error) {
+	list, err := e.FetchTickers([]string{symbol}, params)
+	if err != nil {
+		return nil, err
+	}
+	if len(list) == 0 {
+		return nil, errs.NewMsg(errs.CodeDataNotFound, "no ticker for %s", symbol)
+	}
+	return list[0], nil
+}
+
+func (e *Yahoo) FetchTickerPrice(symbol string, params map[string]interface{}) (map[string]float64, *errs.Error) {
+	var symbols []string
+	if symbol == "" {
+		if v, ok := params[banexg.ParamSymbols]; ok && v != nil {
+			symbols, _ = v.([]string)
+		}
+	} else {
+		symbols = []string{symbol}
+	}
+	if len(symbols) == 0 {
+		return nil, errs.NewMsg(errs.CodeParamRequired, "symbol(s) required")
+	}
+	list, err := e.FetchTickers(symbols, params)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]float64, len(list))
+	for _, t := range list {
+		out[t.Symbol] = t.Last
+	}
+	return out, nil
+}
+
+func (e *Yahoo) Close() *errs.Error {
+	return nil
+}

--- a/yahoo/biz.go
+++ b/yahoo/biz.go
@@ -61,14 +61,9 @@ func (e *Yahoo) Init() *errs.Error {
 func (e *Yahoo) LoadMarkets(reload bool, params map[string]interface{}) (banexg.MarketMap, *errs.Error) {
 	var symbols []string
 	if params != nil {
-		if v, ok := params[banexg.ParamSymbols]; ok && v != nil {
-			symbols, _ = v.([]string)
-		}
+		symbols = coerceSymbols(params[banexg.ParamSymbols])
 	}
 	for _, s := range symbols {
-		if s == "" {
-			continue
-		}
 		e.registerMarket(buildMarket(s))
 	}
 	e.MarketsLock.Lock()
@@ -185,9 +180,7 @@ func (e *Yahoo) FetchTicker(symbol string, params map[string]interface{}) (*bane
 func (e *Yahoo) FetchTickerPrice(symbol string, params map[string]interface{}) (map[string]float64, *errs.Error) {
 	var symbols []string
 	if symbol == "" {
-		if v, ok := params[banexg.ParamSymbols]; ok && v != nil {
-			symbols, _ = v.([]string)
-		}
+		symbols = coerceSymbols(params[banexg.ParamSymbols])
 	} else {
 		symbols = []string{symbol}
 	}

--- a/yahoo/biz_test.go
+++ b/yahoo/biz_test.go
@@ -1,0 +1,136 @@
+package yahoo
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/banbox/banexg"
+)
+
+// liveOrSkip skips tests that hit the real Yahoo Finance API unless
+// BANEXG_YAHOO_LIVE=1 is set, so the package is testable in offline CI.
+func liveOrSkip(t *testing.T) *Yahoo {
+	t.Helper()
+	if os.Getenv("BANEXG_YAHOO_LIVE") != "1" {
+		t.Skip("set BANEXG_YAHOO_LIVE=1 to run live Yahoo Finance tests")
+	}
+	exg, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return exg
+}
+
+func TestNewExchange_NoNetwork(t *testing.T) {
+	exg, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if exg.ID != "yahoo" {
+		t.Errorf("ID=%q, want yahoo", exg.ID)
+	}
+	if !exg.HasApi(banexg.ApiFetchOHLCV, "") {
+		t.Error("FetchOHLCV must be advertised as supported")
+	}
+	if exg.HasApi(banexg.ApiCreateOrder, "") {
+		t.Error("CreateOrder must NOT be advertised as supported")
+	}
+}
+
+func TestMapMarket_Lazy(t *testing.T) {
+	exg, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	m, err := exg.MapMarket("AAPL", 0)
+	if err != nil {
+		t.Fatalf("MapMarket: %v", err)
+	}
+	if !m.Spot || m.Symbol != "AAPL" || m.Base != "AAPL" || m.Quote != "USD" {
+		t.Errorf("market: %+v", m)
+	}
+}
+
+func TestFetchOHLCV_Daily_AAPL(t *testing.T) {
+	exg := liveOrSkip(t)
+	since := time.Now().AddDate(-10, 0, 0).UnixMilli()
+	klines, err := exg.FetchOHLCV("AAPL", "1d", since, 0, nil)
+	if err != nil {
+		t.Fatalf("FetchOHLCV: %v", err)
+	}
+	if len(klines) < 2000 {
+		t.Errorf("want >=2000 daily bars over 10y, got %d", len(klines))
+	}
+	for i := 1; i < len(klines); i++ {
+		if klines[i].Time <= klines[i-1].Time {
+			t.Fatalf("timestamps not strictly increasing at %d", i)
+		}
+	}
+	last := klines[len(klines)-1]
+	if last.Open <= 0 || last.Close <= 0 || last.High <= 0 || last.Low <= 0 {
+		t.Errorf("invalid last bar: %+v", last)
+	}
+}
+
+func TestFetchOHLCV_1m_AAPL(t *testing.T) {
+	exg := liveOrSkip(t)
+	klines, err := exg.FetchOHLCV("AAPL", "1m", 0, 0, nil)
+	if err != nil {
+		t.Fatalf("FetchOHLCV 1m: %v", err)
+	}
+	if len(klines) == 0 {
+		t.Fatal("got 0 1-minute bars; weekend?")
+	}
+	for _, k := range klines {
+		if k.Open <= 0 || k.Close <= 0 {
+			t.Errorf("invalid bar %+v", k)
+		}
+	}
+}
+
+func TestFetchOHLCV_Hourly_AAPL(t *testing.T) {
+	exg := liveOrSkip(t)
+	klines, err := exg.FetchOHLCV("AAPL", "1h", 0, 0, nil)
+	if err != nil {
+		t.Fatalf("FetchOHLCV 1h: %v", err)
+	}
+	if len(klines) < 100 {
+		t.Errorf("want >=100 hourly bars, got %d", len(klines))
+	}
+}
+
+func TestFetchTickers(t *testing.T) {
+	exg := liveOrSkip(t)
+	tickers, err := exg.FetchTickers([]string{"AAPL", "MSFT", "GOOG"}, nil)
+	if err != nil {
+		t.Fatalf("FetchTickers: %v", err)
+	}
+	if len(tickers) != 3 {
+		t.Errorf("want 3 tickers, got %d", len(tickers))
+	}
+	for _, tk := range tickers {
+		if tk.Last <= 0 {
+			t.Errorf("%s last=%v", tk.Symbol, tk.Last)
+		}
+	}
+}
+
+func TestFetchTicker_Single(t *testing.T) {
+	exg := liveOrSkip(t)
+	tk, err := exg.FetchTicker("AAPL", nil)
+	if err != nil {
+		t.Fatalf("FetchTicker: %v", err)
+	}
+	if tk.Symbol != "AAPL" || tk.Last <= 0 {
+		t.Errorf("ticker: %+v", tk)
+	}
+}
+
+func TestFetchOHLCV_BadSymbol(t *testing.T) {
+	exg := liveOrSkip(t)
+	_, err := exg.FetchOHLCV("ZZZZ_NOT_A_SYMBOL_X", "1d", 0, 0, nil)
+	if err == nil {
+		t.Fatal("expected error for unknown symbol")
+	}
+}

--- a/yahoo/biz_test.go
+++ b/yahoo/biz_test.go
@@ -38,6 +38,21 @@ func TestNewExchange_NoNetwork(t *testing.T) {
 	}
 }
 
+// TestNew_DoesNotMutateOptions guards the regression CodeRabbit flagged on
+// PR #8: New() must not inject defaults into the caller's Options map.
+func TestNew_DoesNotMutateOptions(t *testing.T) {
+	opts := map[string]interface{}{}
+	if _, err := New(opts); err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, ok := opts[banexg.OptUserAgent]; ok {
+		t.Errorf("caller's Options was mutated: UserAgent injected")
+	}
+	if len(opts) != 0 {
+		t.Errorf("caller's Options was mutated: extra keys=%v", opts)
+	}
+}
+
 func TestMapMarket_Lazy(t *testing.T) {
 	exg, err := New(nil)
 	if err != nil {

--- a/yahoo/biz_test.go
+++ b/yahoo/biz_test.go
@@ -134,3 +134,51 @@ func TestFetchOHLCV_BadSymbol(t *testing.T) {
 		t.Fatal("expected error for unknown symbol")
 	}
 }
+
+// TestFetchOHLCV_AAPL_AllTimeframes hits Yahoo for AAPL across every
+// timeframe the project promises: 1m, 5m, 1h, 4h, 1D, 1W, 1M.
+// Skips when BANEXG_YAHOO_LIVE != 1.
+func TestFetchOHLCV_AAPL_AllTimeframes(t *testing.T) {
+	exg := liveOrSkip(t)
+	cases := []struct {
+		tf      string
+		minBars int
+	}{
+		{"1m", 1},   // intraday recent only (5d window); empty on weekends
+		{"5m", 1},   // last 60d
+		{"1h", 100}, // last 730d
+		{"4h", 25},  // aggregated from 1h
+		{"1D", 200}, // 1y default
+		{"1W", 50},  // weekly, full max
+		{"1M", 12},  // monthly, full max
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.tf, func(t *testing.T) {
+			klines, err := exg.FetchOHLCV("AAPL", c.tf, 0, 0, nil)
+			if err != nil {
+				t.Fatalf("FetchOHLCV %s: %v", c.tf, err)
+			}
+			if len(klines) < c.minBars {
+				t.Fatalf("%s: want >=%d bars, got %d", c.tf, c.minBars, len(klines))
+			}
+			// Sanity: monotonically increasing timestamps, positive OHLC.
+			for i, k := range klines {
+				if k.Open <= 0 || k.High <= 0 || k.Low <= 0 || k.Close <= 0 {
+					t.Errorf("%s bar %d non-positive OHLC: %+v", c.tf, i, k)
+				}
+				if k.High < k.Low {
+					t.Errorf("%s bar %d high<low: %+v", c.tf, i, k)
+				}
+				if i > 0 && k.Time <= klines[i-1].Time {
+					t.Fatalf("%s timestamps not strictly increasing at %d", c.tf, i)
+				}
+			}
+			first, last := klines[0], klines[len(klines)-1]
+			t.Logf("%-3s  %d bars  first=%s O=%.2f C=%.2f  last=%s O=%.2f C=%.2f",
+				c.tf, len(klines),
+				time.UnixMilli(first.Time).UTC().Format("2006-01-02 15:04"), first.Open, first.Close,
+				time.UnixMilli(last.Time).UTC().Format("2006-01-02 15:04"), last.Open, last.Close)
+		})
+	}
+}

--- a/yahoo/common.go
+++ b/yahoo/common.go
@@ -1,0 +1,202 @@
+package yahoo
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/banbox/banexg"
+	"github.com/banbox/banexg/errs"
+	"github.com/banbox/banexg/utils"
+)
+
+// makeSign builds the final HTTP request for Yahoo Finance public endpoints.
+// Yahoo requires no auth; we substitute the {symbol} path placeholder and
+// URL-encode remaining params into a query string.
+func makeSign(_ *Yahoo) banexg.FuncSign {
+	return func(api *banexg.Entry, args map[string]interface{}) *banexg.HttpReq {
+		params := utils.SafeParams(args)
+		raw := api.Url
+		if sym, ok := params["symbol"]; ok {
+			s, _ := sym.(string)
+			raw = strings.Replace(raw, "{symbol}", url.PathEscape(s), 1)
+			delete(params, "symbol")
+		}
+		if len(params) > 0 {
+			raw += "?" + utils.UrlEncodeMap(params, true)
+		}
+		return &banexg.HttpReq{
+			Url:     raw,
+			Method:  api.Method,
+			Headers: http.Header{},
+			Private: false,
+		}
+	}
+}
+
+// buildMarket constructs a Spot Market for a Yahoo ticker.
+// Yahoo tickers cover stocks (AAPL), indices (^GSPC), crypto (BTC-USD),
+// futures (ES=F), forex (EURUSD=X). For v1 we treat all as Spot.
+func buildMarket(ticker string) *banexg.Market {
+	base, quote, isIndex := splitTicker(ticker)
+	return &banexg.Market{
+		ID:          ticker,
+		LowercaseID: strings.ToLower(ticker),
+		Symbol:      ticker,
+		Base:        base,
+		Quote:       quote,
+		Type:        banexg.MarketSpot,
+		Spot:        true,
+		Active:      true,
+		FeeSide:     "quote",
+		Precision: &banexg.Precision{
+			Amount:     1,
+			Price:      0.01,
+			Base:       1,
+			Quote:      0.01,
+			ModeAmount: banexg.PrecModeDecimalPlace,
+			ModePrice:  banexg.PrecModeTickSize,
+			ModeBase:   banexg.PrecModeDecimalPlace,
+			ModeQuote:  banexg.PrecModeTickSize,
+		},
+		Limits: &banexg.MarketLimits{
+			Amount: &banexg.LimitRange{Min: 1},
+		},
+		Info: map[string]interface{}{
+			"isIndex": isIndex,
+			"ticker":  ticker,
+		},
+	}
+}
+
+// splitTicker derives a Base/Quote pair from a Yahoo ticker symbol.
+func splitTicker(t string) (base, quote string, isIndex bool) {
+	if t == "" {
+		return "", "USD", false
+	}
+	if t[0] == '^' {
+		return t, "USD", true
+	}
+	if strings.HasSuffix(t, "=X") {
+		core := strings.TrimSuffix(t, "=X")
+		if len(core) == 6 {
+			return core[:3], core[3:], false
+		}
+		return core, "USD", false
+	}
+	if strings.HasSuffix(t, "=F") {
+		return strings.TrimSuffix(t, "=F"), "USD", false
+	}
+	if strings.Contains(t, "-") {
+		parts := strings.SplitN(t, "-", 2)
+		if len(parts) == 2 {
+			return parts[0], parts[1], false
+		}
+	}
+	return t, "USD", false
+}
+
+// chooseRange picks a sensible Yahoo `range` parameter when no explicit
+// since/until is provided. Yahoo accepts: 1d/5d/1mo/3mo/6mo/1y/2y/5y/10y/ytd/max
+// plus the day-count strings 60d/730d for intraday lookback.
+func chooseRange(interval string, limit int) string {
+	switch interval {
+	case "1m":
+		return "5d"
+	case "2m", "5m", "15m", "30m":
+		return "60d"
+	case "60m", "90m":
+		return "730d"
+	case "1d":
+		if limit > 0 && limit <= 252 {
+			return "1y"
+		}
+		return "10y"
+	case "5d", "1wk", "1mo", "3mo":
+		return "max"
+	}
+	return "10y"
+}
+
+// parseChart converts the v8 chart JSON body to []*banexg.Kline.
+// Uses the raw OHLCV under indicators.quote[0]; adjclose is ignored to match
+// the unadjusted convention used by other banexg exchanges.
+func parseChart(body string) ([]*banexg.Kline, *errs.Error) {
+	var resp chartResp
+	if err := utils.UnmarshalString(body, &resp, utils.JsonNumDefault); err != nil {
+		return nil, errs.New(errs.CodeUnmarshalFail, err)
+	}
+	if resp.Chart.Error != nil {
+		return nil, errs.NewMsg(errs.CodeInvalidResponse, "yahoo chart error: %s %s",
+			resp.Chart.Error.Code, resp.Chart.Error.Description)
+	}
+	if len(resp.Chart.Result) == 0 {
+		return nil, errs.NewMsg(errs.CodeDataNotFound, "yahoo chart empty result")
+	}
+	res := resp.Chart.Result[0]
+	if len(res.Indicators.Quote) == 0 {
+		return nil, errs.NewMsg(errs.CodeDataNotFound, "yahoo chart missing indicators")
+	}
+	q := res.Indicators.Quote[0]
+	n := len(res.Timestamp)
+	out := make([]*banexg.Kline, 0, n)
+	for i := 0; i < n; i++ {
+		// Skip bars where any OHLC element is null (e.g. trading halts).
+		if i >= len(q.Open) || q.Open[i] == nil ||
+			i >= len(q.High) || q.High[i] == nil ||
+			i >= len(q.Low) || q.Low[i] == nil ||
+			i >= len(q.Close) || q.Close[i] == nil {
+			continue
+		}
+		var vol float64
+		if i < len(q.Volume) && q.Volume[i] != nil {
+			vol = *q.Volume[i]
+		}
+		out = append(out, &banexg.Kline{
+			Time:   res.Timestamp[i] * 1000,
+			Open:   *q.Open[i],
+			High:   *q.High[i],
+			Low:    *q.Low[i],
+			Close:  *q.Close[i],
+			Volume: vol,
+		})
+	}
+	return out, nil
+}
+
+func parseQuote(body string) ([]*banexg.Ticker, *errs.Error) {
+	var resp quoteResp
+	if err := utils.UnmarshalString(body, &resp, utils.JsonNumDefault); err != nil {
+		return nil, errs.New(errs.CodeUnmarshalFail, err)
+	}
+	if resp.QuoteResponse.Error != nil {
+		return nil, errs.NewMsg(errs.CodeInvalidResponse, "yahoo quote error: %s %s",
+			resp.QuoteResponse.Error.Code, resp.QuoteResponse.Error.Description)
+	}
+	out := make([]*banexg.Ticker, 0, len(resp.QuoteResponse.Result))
+	for _, r := range resp.QuoteResponse.Result {
+		out = append(out, &banexg.Ticker{
+			Symbol:        r.Symbol,
+			TimeStamp:     r.RegularMarketTime * 1000,
+			Last:          r.RegularMarketPrice,
+			Open:          r.RegularMarketOpen,
+			High:          r.RegularMarketDayHigh,
+			Low:           r.RegularMarketDayLow,
+			Close:         r.RegularMarketPrice,
+			Bid:           r.Bid,
+			Ask:           r.Ask,
+			BidVolume:     float64(r.BidSize),
+			AskVolume:     float64(r.AskSize),
+			BaseVolume:    float64(r.RegularMarketVolume),
+			PreviousClose: r.RegularMarketPreviousClose,
+			Change:        r.RegularMarketChange,
+			Percentage:    r.RegularMarketChangePercent,
+			Info: map[string]interface{}{
+				"currency":  r.Currency,
+				"exchange":  r.Exchange,
+				"quoteType": r.QuoteType,
+			},
+		})
+	}
+	return out, nil
+}

--- a/yahoo/common.go
+++ b/yahoo/common.go
@@ -164,6 +164,46 @@ func parseChart(body string) ([]*banexg.Kline, *errs.Error) {
 	return out, nil
 }
 
+// coerceSymbols extracts a []string of tickers from a heterogeneous params
+// value. Callers commonly pass []string, but JSON-decoded params arrive as
+// []interface{} and human-typed config often uses a comma-separated string.
+// Empty/whitespace entries are dropped.
+func coerceSymbols(v interface{}) []string {
+	if v == nil {
+		return nil
+	}
+	switch t := v.(type) {
+	case []string:
+		out := make([]string, 0, len(t))
+		for _, s := range t {
+			if s = strings.TrimSpace(s); s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	case []interface{}:
+		out := make([]string, 0, len(t))
+		for _, item := range t {
+			if s, ok := item.(string); ok {
+				if s = strings.TrimSpace(s); s != "" {
+					out = append(out, s)
+				}
+			}
+		}
+		return out
+	case string:
+		parts := strings.Split(t, ",")
+		out := make([]string, 0, len(parts))
+		for _, s := range parts {
+			if s = strings.TrimSpace(s); s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
 // aggregate groups input klines into buckets of `bucketMs` size, aligned to
 // epoch (i.e. bucket start = floor(t / bucketMs) * bucketMs). Used for
 // timeframes Yahoo doesn't return natively — currently 4h built on 1h.

--- a/yahoo/common.go
+++ b/yahoo/common.go
@@ -105,7 +105,7 @@ func chooseRange(interval string, limit int) string {
 		return "5d"
 	case "2m", "5m", "15m", "30m":
 		return "60d"
-	case "60m", "90m":
+	case "60m", "90m", "4h":
 		return "730d"
 	case "1d":
 		if limit > 0 && limit <= 252 {
@@ -162,6 +162,50 @@ func parseChart(body string) ([]*banexg.Kline, *errs.Error) {
 		})
 	}
 	return out, nil
+}
+
+// aggregate groups input klines into buckets of `bucketMs` size, aligned to
+// epoch (i.e. bucket start = floor(t / bucketMs) * bucketMs). Used for
+// timeframes Yahoo doesn't return natively — currently 4h built on 1h.
+// Volumes sum, highs/lows extend, open is taken from the first bar in the
+// bucket, close from the last.
+func aggregate(in []*banexg.Kline, bucketMs int64) []*banexg.Kline {
+	if len(in) == 0 || bucketMs <= 0 {
+		return in
+	}
+	out := make([]*banexg.Kline, 0, len(in))
+	var cur *banexg.Kline
+	var curBucket int64 = -1
+	for _, k := range in {
+		bucket := k.Time / bucketMs
+		if cur == nil || bucket != curBucket {
+			if cur != nil {
+				out = append(out, cur)
+			}
+			cur = &banexg.Kline{
+				Time:   bucket * bucketMs,
+				Open:   k.Open,
+				High:   k.High,
+				Low:    k.Low,
+				Close:  k.Close,
+				Volume: k.Volume,
+			}
+			curBucket = bucket
+			continue
+		}
+		if k.High > cur.High {
+			cur.High = k.High
+		}
+		if k.Low < cur.Low {
+			cur.Low = k.Low
+		}
+		cur.Close = k.Close
+		cur.Volume += k.Volume
+	}
+	if cur != nil {
+		out = append(out, cur)
+	}
+	return out
 }
 
 func parseQuote(body string) ([]*banexg.Ticker, *errs.Error) {

--- a/yahoo/common_test.go
+++ b/yahoo/common_test.go
@@ -135,6 +135,38 @@ func TestAggregate_Empty(t *testing.T) {
 	}
 }
 
+func TestCoerceSymbols(t *testing.T) {
+	cases := []struct {
+		name string
+		in   interface{}
+		want []string
+	}{
+		{"slice", []string{"AAPL", "MSFT"}, []string{"AAPL", "MSFT"}},
+		{"slice_trim", []string{" AAPL ", "", "MSFT"}, []string{"AAPL", "MSFT"}},
+		{"interface_slice", []interface{}{"AAPL", "MSFT"}, []string{"AAPL", "MSFT"}},
+		{"interface_slice_mixed_types", []interface{}{"AAPL", 42, "MSFT"}, []string{"AAPL", "MSFT"}},
+		{"comma_string", "AAPL,MSFT,GOOG", []string{"AAPL", "MSFT", "GOOG"}},
+		{"comma_with_spaces", "AAPL, MSFT , , GOOG", []string{"AAPL", "MSFT", "GOOG"}},
+		{"single_string", "AAPL", []string{"AAPL"}},
+		{"nil", nil, nil},
+		{"unknown_type", 42, nil},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			got := coerceSymbols(c.in)
+			if len(got) != len(c.want) {
+				t.Fatalf("len got=%d want=%d (%v)", len(got), len(c.want), got)
+			}
+			for i := range got {
+				if got[i] != c.want[i] {
+					t.Errorf("[%d] got=%q want=%q", i, got[i], c.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestChooseRange(t *testing.T) {
 	cases := map[string]string{
 		"1m":  "5d",

--- a/yahoo/common_test.go
+++ b/yahoo/common_test.go
@@ -2,6 +2,8 @@ package yahoo
 
 import (
 	"testing"
+
+	"github.com/banbox/banexg"
 )
 
 func TestSplitTicker(t *testing.T) {
@@ -96,6 +98,40 @@ func TestParseQuote_OK(t *testing.T) {
 	}
 	if tk.TimeStamp != 1700000000*1000 {
 		t.Errorf("ts want %d, got %d", 1700000000*1000, tk.TimeStamp)
+	}
+}
+
+func TestAggregate_4h(t *testing.T) {
+	// 8 hourly bars starting at 2024-01-01 00:00 UTC → expect 2 bars of 4h.
+	hour := int64(60 * 60 * 1000)
+	t0 := int64(1704067200000) // 2024-01-01T00:00:00Z, aligned to 4h boundary
+	in := []*banexg.Kline{
+		{Time: t0 + 0*hour, Open: 100, High: 102, Low: 99, Close: 101, Volume: 10},
+		{Time: t0 + 1*hour, Open: 101, High: 105, Low: 100, Close: 104, Volume: 20},
+		{Time: t0 + 2*hour, Open: 104, High: 106, Low: 103, Close: 105, Volume: 30},
+		{Time: t0 + 3*hour, Open: 105, High: 107, Low: 102, Close: 106, Volume: 40},
+		{Time: t0 + 4*hour, Open: 106, High: 108, Low: 105, Close: 107, Volume: 50},
+		{Time: t0 + 5*hour, Open: 107, High: 109, Low: 106, Close: 108, Volume: 60},
+		{Time: t0 + 6*hour, Open: 108, High: 110, Low: 107, Close: 109, Volume: 70},
+		{Time: t0 + 7*hour, Open: 109, High: 111, Low: 108, Close: 110, Volume: 80},
+	}
+	out := aggregate(in, 4*hour)
+	if len(out) != 2 {
+		t.Fatalf("want 2 4h bars, got %d", len(out))
+	}
+	if out[0].Time != t0 || out[0].Open != 100 || out[0].Close != 106 ||
+		out[0].High != 107 || out[0].Low != 99 || out[0].Volume != 100 {
+		t.Errorf("bucket0 wrong: %+v", out[0])
+	}
+	if out[1].Time != t0+4*hour || out[1].Open != 106 || out[1].Close != 110 ||
+		out[1].High != 111 || out[1].Low != 105 || out[1].Volume != 260 {
+		t.Errorf("bucket1 wrong: %+v", out[1])
+	}
+}
+
+func TestAggregate_Empty(t *testing.T) {
+	if got := aggregate(nil, 4*60*60*1000); got != nil {
+		t.Errorf("want nil for empty input, got %v", got)
 	}
 }
 

--- a/yahoo/common_test.go
+++ b/yahoo/common_test.go
@@ -1,0 +1,118 @@
+package yahoo
+
+import (
+	"testing"
+)
+
+func TestSplitTicker(t *testing.T) {
+	cases := []struct {
+		in      string
+		base    string
+		quote   string
+		isIndex bool
+	}{
+		{"AAPL", "AAPL", "USD", false},
+		{"^GSPC", "^GSPC", "USD", true},
+		{"BTC-USD", "BTC", "USD", false},
+		{"EURUSD=X", "EUR", "USD", false},
+		{"ES=F", "ES", "USD", false},
+		{"BRK-B", "BRK", "B", false}, // BRK-B will look like a pair; documented limitation
+		{"", "", "USD", false},
+	}
+	for _, c := range cases {
+		b, q, ix := splitTicker(c.in)
+		if b != c.base || q != c.quote || ix != c.isIndex {
+			t.Errorf("splitTicker(%q)=(%q,%q,%v), want (%q,%q,%v)",
+				c.in, b, q, ix, c.base, c.quote, c.isIndex)
+		}
+	}
+}
+
+func TestParseChart_OK(t *testing.T) {
+	body := `{
+      "chart": {
+        "result": [{
+          "meta": {"symbol":"AAPL","currency":"USD"},
+          "timestamp": [1700000000, 1700086400, 1700172800],
+          "indicators": {
+            "quote": [{
+              "open":   [150.0, 151.5, null],
+              "high":   [152.0, 152.5, 153.0],
+              "low":    [149.0, 150.5, 151.0],
+              "close":  [151.5, 152.0, 152.5],
+              "volume": [1000000, 1200000, null]
+            }]
+          }
+        }],
+        "error": null
+      }
+    }`
+	klines, err := parseChart(body)
+	if err != nil {
+		t.Fatalf("parseChart error: %v", err)
+	}
+	if len(klines) != 2 {
+		t.Fatalf("want 2 klines (3rd has null open), got %d", len(klines))
+	}
+	if klines[0].Time != 1700000000*1000 || klines[0].Open != 150.0 || klines[0].Close != 151.5 {
+		t.Errorf("first kline mismatch: %+v", klines[0])
+	}
+	if klines[1].Volume != 1200000 {
+		t.Errorf("second volume want 1.2M, got %v", klines[1].Volume)
+	}
+}
+
+func TestParseChart_Error(t *testing.T) {
+	body := `{"chart":{"result":null,"error":{"code":"Not Found","description":"No data"}}}`
+	if _, err := parseChart(body); err == nil {
+		t.Fatal("expected error for chart error response")
+	}
+}
+
+func TestParseQuote_OK(t *testing.T) {
+	body := `{
+      "quoteResponse": {
+        "result": [
+          {"symbol":"AAPL","regularMarketPrice":190.5,"regularMarketDayHigh":191.0,
+           "regularMarketDayLow":189.0,"regularMarketOpen":190.0,
+           "regularMarketPreviousClose":189.5,"regularMarketChange":1.0,
+           "regularMarketChangePercent":0.53,"regularMarketVolume":50000000,
+           "bid":190.4,"ask":190.6,"regularMarketTime":1700000000,
+           "currency":"USD","exchange":"NMS","quoteType":"EQUITY"}
+        ],
+        "error": null
+      }
+    }`
+	tickers, err := parseQuote(body)
+	if err != nil {
+		t.Fatalf("parseQuote error: %v", err)
+	}
+	if len(tickers) != 1 {
+		t.Fatalf("want 1 ticker, got %d", len(tickers))
+	}
+	tk := tickers[0]
+	if tk.Symbol != "AAPL" || tk.Last != 190.5 || tk.High != 191.0 || tk.Low != 189.0 {
+		t.Errorf("ticker mismatch: %+v", tk)
+	}
+	if tk.TimeStamp != 1700000000*1000 {
+		t.Errorf("ts want %d, got %d", 1700000000*1000, tk.TimeStamp)
+	}
+}
+
+func TestChooseRange(t *testing.T) {
+	cases := map[string]string{
+		"1m":  "5d",
+		"5m":  "60d",
+		"60m": "730d",
+		"1d":  "10y",
+		"1wk": "max",
+	}
+	for tf, want := range cases {
+		if got := chooseRange(tf, 0); got != want {
+			t.Errorf("chooseRange(%q)=%q, want %q", tf, got, want)
+		}
+	}
+	if got := chooseRange("1d", 50); got != "1y" {
+		t.Errorf("chooseRange(1d,50)=%q, want 1y", got)
+	}
+}

--- a/yahoo/data.go
+++ b/yahoo/data.go
@@ -1,0 +1,14 @@
+package yahoo
+
+const (
+	HostQuery1 = "query1"
+	HostQuery2 = "query2"
+
+	MidChartGet = "ChartGet"
+	MidQuoteGet = "QuoteGet"
+)
+
+// Yahoo blocks the default `Go-http-client/1.1` UA with HTTP 403,
+// so we send a real browser-style UA by default.
+const defaultUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
+	"AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"

--- a/yahoo/entry.go
+++ b/yahoo/entry.go
@@ -3,12 +3,13 @@ package yahoo
 import (
 	"github.com/banbox/banexg"
 	"github.com/banbox/banexg/errs"
+	"github.com/banbox/banexg/utils"
 )
 
 func New(Options map[string]interface{}) (*Yahoo, *errs.Error) {
-	if Options == nil {
-		Options = make(map[string]interface{})
-	}
+	// Work on a copy so we don't mutate the caller's map (e.g. injecting our
+	// default User-Agent into a shared option map shared across exchanges).
+	Options = utils.SafeParams(Options)
 	if _, ok := Options[banexg.OptUserAgent]; !ok {
 		Options[banexg.OptUserAgent] = defaultUserAgent
 	}

--- a/yahoo/entry.go
+++ b/yahoo/entry.go
@@ -1,0 +1,80 @@
+package yahoo
+
+import (
+	"github.com/banbox/banexg"
+	"github.com/banbox/banexg/errs"
+)
+
+func New(Options map[string]interface{}) (*Yahoo, *errs.Error) {
+	if Options == nil {
+		Options = make(map[string]interface{})
+	}
+	if _, ok := Options[banexg.OptUserAgent]; !ok {
+		Options[banexg.OptUserAgent] = defaultUserAgent
+	}
+	exg := &Yahoo{
+		Exchange: &banexg.Exchange{
+			ExgInfo: &banexg.ExgInfo{
+				ID:        "yahoo",
+				Name:      "Yahoo Finance",
+				Countries: []string{"US"},
+				FixedLvg:  true,
+			},
+			RateLimit: 200,
+			Options:   Options,
+			Hosts: &banexg.ExgHosts{
+				Prod: map[string]string{
+					HostQuery1: "https://query1.finance.yahoo.com",
+					HostQuery2: "https://query2.finance.yahoo.com",
+				},
+			},
+			Apis: map[string]*banexg.Entry{
+				MidChartGet: {Path: "v8/finance/chart/{symbol}", Host: HostQuery1, Method: "GET", CacheSecs: 60},
+				MidQuoteGet: {Path: "v7/finance/quote", Host: HostQuery1, Method: "GET", CacheSecs: 5},
+			},
+			Has: map[string]map[string]int{
+				"": {
+					banexg.ApiFetchTicker:           banexg.HasOk,
+					banexg.ApiFetchTickers:          banexg.HasOk,
+					banexg.ApiFetchTickerPrice:      banexg.HasOk,
+					banexg.ApiFetchOHLCV:            banexg.HasOk,
+					banexg.ApiLoadLeverageBrackets:  banexg.HasFail,
+					banexg.ApiGetLeverage:           banexg.HasFail,
+					banexg.ApiFetchOrderBook:        banexg.HasFail,
+					banexg.ApiFetchOrder:            banexg.HasFail,
+					banexg.ApiFetchOrders:           banexg.HasFail,
+					banexg.ApiFetchBalance:          banexg.HasFail,
+					banexg.ApiFetchAccountPositions: banexg.HasFail,
+					banexg.ApiFetchPositions:        banexg.HasFail,
+					banexg.ApiFetchOpenOrders:       banexg.HasFail,
+					banexg.ApiCreateOrder:           banexg.HasFail,
+					banexg.ApiEditOrder:             banexg.HasFail,
+					banexg.ApiCancelOrder:           banexg.HasFail,
+					banexg.ApiSetLeverage:           banexg.HasFail,
+					banexg.ApiCalcMaintMargin:       banexg.HasFail,
+					banexg.ApiWatchOrderBooks:       banexg.HasFail,
+					banexg.ApiUnWatchOrderBooks:     banexg.HasFail,
+					banexg.ApiWatchOHLCVs:           banexg.HasFail,
+					banexg.ApiUnWatchOHLCVs:         banexg.HasFail,
+					banexg.ApiWatchMarkPrices:       banexg.HasFail,
+					banexg.ApiUnWatchMarkPrices:     banexg.HasFail,
+					banexg.ApiWatchTrades:           banexg.HasFail,
+					banexg.ApiUnWatchTrades:         banexg.HasFail,
+					banexg.ApiWatchMyTrades:         banexg.HasFail,
+					banexg.ApiWatchBalance:          banexg.HasFail,
+					banexg.ApiWatchPositions:        banexg.HasFail,
+					banexg.ApiWatchAccountConfig:    banexg.HasFail,
+				},
+			},
+		},
+	}
+	if err := exg.Init(); err != nil {
+		return nil, err
+	}
+	exg.Sign = makeSign(exg)
+	return exg, nil
+}
+
+func NewExchange(Options map[string]interface{}) (banexg.BanExchange, *errs.Error) {
+	return New(Options)
+}

--- a/yahoo/types.go
+++ b/yahoo/types.go
@@ -1,0 +1,71 @@
+package yahoo
+
+import "github.com/banbox/banexg"
+
+// Yahoo wraps the base Exchange to provide read-only Yahoo Finance market data.
+type Yahoo struct {
+	*banexg.Exchange
+}
+
+// chartResp is the v8/finance/chart response shape.
+type chartResp struct {
+	Chart struct {
+		Result []chartResult `json:"result"`
+		Error  *yahooErr     `json:"error"`
+	} `json:"chart"`
+}
+
+type chartResult struct {
+	Meta struct {
+		Symbol             string  `json:"symbol"`
+		Currency           string  `json:"currency"`
+		ExchangeName       string  `json:"exchangeName"`
+		InstrumentType     string  `json:"instrumentType"`
+		RegularMarketPrice float64 `json:"regularMarketPrice"`
+		Gmtoffset          int64   `json:"gmtoffset"`
+		Timezone           string  `json:"timezone"`
+	} `json:"meta"`
+	Timestamp  []int64 `json:"timestamp"`
+	Indicators struct {
+		Quote []struct {
+			Open   []*float64 `json:"open"`
+			High   []*float64 `json:"high"`
+			Low    []*float64 `json:"low"`
+			Close  []*float64 `json:"close"`
+			Volume []*float64 `json:"volume"`
+		} `json:"quote"`
+	} `json:"indicators"`
+}
+
+// quoteResp is the v7/finance/quote response shape.
+type quoteResp struct {
+	QuoteResponse struct {
+		Result []quoteRes `json:"result"`
+		Error  *yahooErr  `json:"error"`
+	} `json:"quoteResponse"`
+}
+
+type quoteRes struct {
+	Symbol                     string  `json:"symbol"`
+	Currency                   string  `json:"currency"`
+	Exchange                   string  `json:"exchange"`
+	QuoteType                  string  `json:"quoteType"`
+	RegularMarketPrice         float64 `json:"regularMarketPrice"`
+	RegularMarketDayHigh       float64 `json:"regularMarketDayHigh"`
+	RegularMarketDayLow        float64 `json:"regularMarketDayLow"`
+	RegularMarketOpen          float64 `json:"regularMarketOpen"`
+	RegularMarketPreviousClose float64 `json:"regularMarketPreviousClose"`
+	RegularMarketChange        float64 `json:"regularMarketChange"`
+	RegularMarketChangePercent float64 `json:"regularMarketChangePercent"`
+	RegularMarketVolume        int64   `json:"regularMarketVolume"`
+	Bid                        float64 `json:"bid"`
+	Ask                        float64 `json:"ask"`
+	BidSize                    int64   `json:"bidSize"`
+	AskSize                    int64   `json:"askSize"`
+	RegularMarketTime          int64   `json:"regularMarketTime"`
+}
+
+type yahooErr struct {
+	Code        string `json:"code"`
+	Description string `json:"description"`
+}


### PR DESCRIPTION
An assessment of how yahoo works to download data from the USA using OHLCV.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Yahoo Finance as a supported exchange provider for accessing historical and real-time market data
  * Retrieve OHLCV candlesticks across multiple timeframes including 1-minute, hourly, and daily intervals
  * Fetch ticker prices and quote information for multiple symbols

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/banbox/banexg/pull/8)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->