### PR TITLE
fix(bybit): ignore non-trade execution events

### DIFF
--- a/bybit/ws_handle_test.go
+++ b/bybit/ws_handle_test.go
@@ -236,6 +236,7 @@ func TestHandleWsExecutions(t *testing.T) {
 			"execValue":   "10",
 			"execFee":     "0.01",
 			"feeCurrency": "USDT",
+			"execType":    "Trade",
 			"execTime":    "1700000000000",
 			"isMaker":     true,
 		},

--- a/bybit/ws_parse.go
+++ b/bybit/ws_parse.go
@@ -385,7 +385,9 @@ func parseBybitWsKlineItem(item map[string]interface{}) *banexg.Kline {
 }
 
 func parseBybitWsMyTrade(e *Bybit, item map[string]interface{}, marketType string) *banexg.MyTrade {
-	if item == nil {
+	// The execution stream also carries non-fill events (for example, funding).
+	// Only trades represent order fills and may be forwarded as MyTrade.
+	if item == nil || bybitWsString(item["execType"]) != "Trade" {
 		return nil
 	}
 	marketID := bybitWsString(item["symbol"])

--- a/bybit/ws_parse_test.go
+++ b/bybit/ws_parse_test.go
@@ -99,6 +99,7 @@ func TestParseBybitWsMyTrade(t *testing.T) {
 		"execValue":   "9.95",
 		"execFee":     "0.01",
 		"feeCurrency": "USDT",
+		"execType":    "Trade",
 		"execTime":    "1700000000000",
 		"isMaker":     true,
 	}
@@ -114,6 +115,27 @@ func TestParseBybitWsMyTrade(t *testing.T) {
 	}
 	if trade.Fee == nil || trade.Fee.Currency != "USDT" {
 		t.Fatalf("unexpected fee: %+v", trade.Fee)
+	}
+}
+
+func TestParseBybitWsMyTradeIgnoresNonTradeExecutions(t *testing.T) {
+	exg := mustNewBybit(t, "Bybit")
+	seedMarket(exg, "BTCUSDT", "BTC/USDT:USDT", banexg.MarketLinear)
+
+	for _, execType := range []string{"Funding", "SessionSettlePnL"} {
+		item := map[string]interface{}{
+			"symbol":     "BTCUSDT",
+			"orderId":    "exchange-order",
+			"side":       "Sell",
+			"execType":   execType,
+			"execQty":    "0.1",
+			"execPrice":  "100",
+			"closedSize": "0",
+			"execTime":   "1700000000000",
+		}
+		if trade := parseBybitWsMyTrade(exg, item, banexg.MarketLinear); trade != nil {
+			t.Fatalf("%s execution must not produce MyTrade: %+v", execType, trade)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- only forward Bybit execution messages with `execType == "Trade"` as `MyTrade`
- ignore funding and settlement execution events so they cannot be interpreted as order fills
- cover Funding and SessionSettlePnL, and update normal-trade fixtures with `execType: Trade`

## Test
- `go test ./bybit`